### PR TITLE
Whitelist IPene til Slack

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -37,6 +37,12 @@ spec:
       external:
         - host: api.github.com
         - host: slack.com
+        - ipv4: 3.68.124.95
+        - ipv4: 52.29.238.212
+        - ipv4: 3.68.175.98
+        - ipv4: 18.159.197.225
+        - ipv4: 3.68.124.168
+        - ipv4: 3.68.170.153
   readiness:
     path: /internal/health
     initialDelay: 10


### PR DESCRIPTION
Vi har hatt en del utfordringer med at vi får SSLHandshakeException når vi prøver å poste til Slack.

Det kan virke som det er noe køl med hvordan brannmuren ut håndterer de ulike IPene til Slack, og foreløpig så virker det mer stabilt å liste opp alle kjente IPer.